### PR TITLE
Pass deps to PDC in the new style.

### DIFF
--- a/pdcupdater/handlers/modules.py
+++ b/pdcupdater/handlers/modules.py
@@ -116,19 +116,10 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
         scmurl = body['scmurl']
         mmd = self.get_mmd_from_scm(scmurl)
 
-        runtime_deps = []
-        for dep, ver in mmd.requires.items():
-            if ver is not None:
-                runtime_deps.append({'dependency': "{} >= {}".format(dep, ver)})
-            else:
-                runtime_deps.append({'dependency': dep})
-
-        build_deps = []
-        for dep, ver in mmd.buildrequires.items():
-            if ver is not None:
-                build_deps.append({'dependency': "{} >= {}".format(dep, ver)})
-            else:
-                build_deps.append({'dependency': dep})
+        runtime_deps = [{'dependency': dependency, 'stream': stream}
+                        for dependency, stream in mmd.requires.items()]
+        build_deps = [{'dependency': dependency, 'stream': stream}
+                      for dependency, stream in mmd.buildrequires.items()]
 
         name = body['name']
         # TODO: PDC has to be patched to support stream/version instead of


### PR DESCRIPTION
This is only one half of the new modulemd-1.0 problems to solve.

This relates to:

- https://github.com/fedora-modularity/product-definition-center/pull/9
- https://pagure.io/fm-orchestrator/pull-request/190