### PR TITLE
Fix koji_tag - it has to be based on name-stream-version, not just name.

### DIFF
--- a/pdcupdater/handlers/modules.py
+++ b/pdcupdater/handlers/modules.py
@@ -95,7 +95,7 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
         release = body['version']
         variant_uid = "{n}-{v}-{r}".format(n=name, v=version, r=release)
         variant_id = name
-        koji_tag = "module-" + variant_id
+        koji_tag = "module-" + variant_uid.lower()
 
         data = {
             'variant_id': variant_id,


### PR DESCRIPTION
This is follow up of https://github.com/fedora-modularity/pdc-updater/commit/a18edb91c8b600ef266e142d89bca87bf09ae8b8. That commit changed the variant_id value, but it should also change the koji_tag.