### PR TITLE
Do not add entries to PDC according to Module in 'init' state, because there are not all data in the message in that time

### DIFF
--- a/pdcupdater/handlers/modules.py
+++ b/pdcupdater/handlers/modules.py
@@ -18,10 +18,11 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
     """ When the state of a module changes. """
 
     tree_processing_states = set(('done', 'ready'))
-    other_states = set(('init', 'wait', 'building'))
+    other_states = set(('wait', 'building'))
+    irelevant_states = set(('init',))
     relevant_states = tree_processing_states.union(other_states)
     error_states = set(('failed',))
-    valid_states = relevant_states.union(error_states)
+    valid_states = relevant_states.union(error_states).union(irelevant_states)
 
     tree_id_re = re.compile(
         r"(?P<name>[^-]+)-(?P<version>[^-]+)-"


### PR DESCRIPTION
When module build state changes to "init", the module build object has just been created. It does not contain the proper modulemd yaml file, or the proper time_modified field and so on.

We could fix it on the MBS side by emitting "init" msg just after we know all the data, but that would be right before we send "wait" msg, so it would not make any sense to send two same messages just with different state.

I therefore decided to keep the current code in the MBS and change the pdc-updater instead to not handle "init". It could be still useful to handle "init" in some other services, but not in the pdc-updater, which need very accurate data about the module to create entry in PDC.

Another possible solution to this is to not emit "init" at all.

I presume other people will have different opinion on this issue - I'm fine with fixing it another way once we reach the consensus.